### PR TITLE
Updated the coveralls gem to 0.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,91 @@
+PATH
+  remote: .
+  specs:
+    lita-cron (0.0.3)
+      lita (>= 2.7)
+      rufus-scheduler (= 2.0.24)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coveralls (0.7.1)
+      multi_json (~> 1.3)
+      rest-client
+      simplecov (>= 0.7)
+      term-ansicolor
+      thor
+    diff-lcs (1.2.5)
+    docile (1.1.5)
+    faraday (0.9.0)
+      multipart-post (>= 1.2, < 3)
+    http_router (0.11.1)
+      rack (>= 1.0.0)
+      url_mount (~> 0.2.1)
+    i18n (0.6.11)
+    ice_nine (0.11.0)
+    lita (4.0.2)
+      bundler (>= 1.3)
+      faraday (>= 0.8.7)
+      http_router (>= 0.11.1)
+      i18n (>= 0.6.9)
+      ice_nine (>= 0.11.0)
+      multi_json (>= 1.7.7)
+      puma (>= 2.7.1)
+      rack (>= 1.5.2)
+      rb-readline (>= 0.5.1)
+      redis-namespace (>= 1.3.0)
+      thor (>= 0.18.1)
+    mime-types (2.4.3)
+    multi_json (1.10.1)
+    multipart-post (2.0.0)
+    netrc (0.9.0)
+    puma (2.10.2)
+      rack (>= 1.1, < 2.0)
+    rack (1.5.2)
+    rake (10.4.0)
+    rb-readline (0.5.1)
+    redis (3.1.0)
+    redis-namespace (1.5.1)
+      redis (~> 3.0, >= 3.0.4)
+    rest-client (1.7.2)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
+    rufus-scheduler (2.0.24)
+      tzinfo (>= 0.3.22)
+    simplecov (0.9.1)
+      docile (~> 1.1.0)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.8.0)
+    simplecov-html (0.8.0)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
+    thor (0.19.1)
+    thread_safe (0.3.4)
+    tins (1.3.3)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    url_mount (0.2.1)
+      rack
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.3)
+  coveralls
+  lita-cron!
+  rake
+  rspec (>= 3.0.0.beta2)
+  simplecov


### PR DESCRIPTION
coveralls has been successfully updated from version 0.7.1 to version 0.7.2.
