### PR TITLE
Updated the netrc gem to 0.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
     mime-types (2.4.3)
     multi_json (1.10.1)
     multipart-post (2.0.0)
-    netrc (0.8.0)
+    netrc (0.9.0)
     puma (2.9.1)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)


### PR DESCRIPTION
netrc has been successfully updated from version 0.8.0 to version 0.9.0.
